### PR TITLE
fix(camelcase-api-field): Allow camelcase for API result 

### DIFF
--- a/src/vaultwarden/clients/bitwarden.py
+++ b/src/vaultwarden/clients/bitwarden.py
@@ -67,6 +67,12 @@ class BitwardenAPIClient:
         )
         self._connect_token = ConnectToken.model_validate_json(resp.text)
 
+        self._connect_token.master_key = make_master_key(
+            password=self.password,
+            salt=self.email,
+            iterations=self._connect_token.KdfIterations,
+        )
+
     def _set_connect_token(self):
         headers = {
             "content-type": "application/x-www-form-urlencoded; charset=utf-8",

--- a/src/vaultwarden/clients/vaultwarden.py
+++ b/src/vaultwarden/clients/vaultwarden.py
@@ -1,6 +1,6 @@
 import http
 from http.cookiejar import Cookie
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from uuid import UUID
 
 from httpx import Client, HTTPStatusError, Response
@@ -43,7 +43,7 @@ class VaultwardenAdminClient:
         if preload_users:
             self._load_users()
 
-    def _get_admin_cookie(self) -> Optional[Cookie]:
+    def _get_admin_cookie(self) -> Cookie | None:
         """Get the session cookie, required to authenticate requests"""
         bw_cookies = (
             c for c in self._http_client.cookies.jar if c.name == "VW_ADMIN"

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -230,7 +230,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
             if collection in _current_collections:
                 continue
             user = UserCollection(
-                Id=collection,
+                CollectionId=collection,
                 UserId=self.Id,
                 ReadOnly=False,
                 HidePasswords=False,
@@ -295,7 +295,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
         self.Collections = [
             UserCollection(
                 UserId=self.Id,
-                Id=coll,
+                CollectionId=coll,
                 ReadOnly=False,
                 HidePasswords=False,
             )

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -1,12 +1,7 @@
 from typing import Generic, TypeVar
 from uuid import UUID
 
-from pydantic import (
-    AliasChoices,
-    Field,
-    TypeAdapter,
-    field_validator,
-)
+from pydantic import AliasChoices, Field, TypeAdapter, field_validator
 from pydantic_core.core_schema import FieldValidationInfo
 
 from vaultwarden.clients.bitwarden import BitwardenAPIClient

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from pydantic import (
     AliasChoices,
-    BaseModel,
     Field,
     TypeAdapter,
     field_validator,

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -2,11 +2,11 @@ from typing import Generic, TypeVar
 from uuid import UUID
 
 from pydantic import (
+    AliasChoices,
     BaseModel,
     Field,
     TypeAdapter,
     field_validator,
-    AliasChoices,
 )
 from pydantic_core.core_schema import FieldValidationInfo
 

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -21,8 +21,8 @@ from vaultwarden.utils.crypto import decrypt, encrypt
 T = TypeVar("T", bound="BitwardenBaseModel")
 
 
-class ResplistBitwarden(BaseModel, Generic[T], extra="allow"):
-    Data: list[T] = Field(alias="data", default=[])
+class ResplistBitwarden(PermissiveBaseModel, Generic[T]):
+    Data: list[T]
 
 
 class BitwardenBaseModel(PermissiveBaseModel):

--- a/src/vaultwarden/models/permissive_model.py
+++ b/src/vaultwarden/models/permissive_model.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+from vaultwarden.utils.string_cases import pascal_case_to_camel_case
+
+
+class PermissiveBaseModel(
+    BaseModel,
+    extra="allow",
+    alias_generator=pascal_case_to_camel_case,
+    populate_by_name=True,
+    arbitrary_types_allowed=True,
+):
+    pass

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -1,13 +1,14 @@
 import time
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import Field, field_validator, AliasChoices
 
 from vaultwarden.models.enum import VaultwardenUserStatus
 from vaultwarden.utils.crypto import decrypt
+from vaultwarden.models.permissive_model import PermissiveBaseModel
 
 
-class ConnectToken(BaseModel, extra="allow"):
+class ConnectToken(PermissiveBaseModel):
     Kdf: int = 0
     KdfIterations: int = 0
     KdfMemory: int | None = None
@@ -44,7 +45,7 @@ class ConnectToken(BaseModel, extra="allow"):
         return decrypt(self.PrivateKey, self.user_key)
 
 
-class ProfileOrganization(BaseModel, extra="allow"):
+class ProfileOrganization(PermissiveBaseModel):
     Id: UUID
     Name: str
     Key: str | None = None
@@ -67,7 +68,7 @@ class ProfileOrganization(BaseModel, extra="allow"):
     UseTotp: bool
 
 
-class UserProfile(BaseModel, extra="allow"):
+class UserProfile(PermissiveBaseModel):
     AvatarColor: str | None
     Culture: str
     Email: str
@@ -85,7 +86,9 @@ class UserProfile(BaseModel, extra="allow"):
     Providers: list = []
     SecurityStamp: str
     TwoFactorEnabled: bool
-    status: VaultwardenUserStatus = Field(alias="_Status")
+    status: VaultwardenUserStatus = Field(
+        validation_alias=AliasChoices("_status", "_Status")
+    )
 
 
 class VaultwardenUser(UserProfile):
@@ -95,10 +98,10 @@ class VaultwardenUser(UserProfile):
 
 
 # TODO: add definition of attribute's types
-class SyncData(BaseModel, extra="allow"):
+class SyncData(PermissiveBaseModel):
     Ciphers: list[dict] = []
     Collections: list[dict] = []
-    Domains: dict = {}
+    Domains: dict | None = {}
     Folders: list[dict] = []
     Policies: list[dict] = []
     Profile: UserProfile

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -32,9 +32,7 @@ class ConnectToken(PermissiveBaseModel):
     def is_expired(self, now=None):
         if now is None:
             now = time.time()
-        if (self.expires_in is not None) and (self.expires_in <= now):
-            return True
-        return False
+        return (self.expires_in is not None) and (self.expires_in <= now)
 
     @property
     def user_key(self):

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -1,11 +1,11 @@
 import time
 from uuid import UUID
 
-from pydantic import Field, field_validator, AliasChoices
+from pydantic import AliasChoices, Field, field_validator
 
 from vaultwarden.models.enum import VaultwardenUserStatus
-from vaultwarden.utils.crypto import decrypt
 from vaultwarden.models.permissive_model import PermissiveBaseModel
+from vaultwarden.utils.crypto import decrypt
 
 
 class ConnectToken(PermissiveBaseModel):
@@ -79,11 +79,11 @@ class UserProfile(PermissiveBaseModel):
     MasterPasswordHint: str | None
     Name: str
     Object: str | None
-    Organizations: list[ProfileOrganization] = []
+    Organizations: list[ProfileOrganization]
     Premium: bool
     PrivateKey: str | None
-    ProviderOrganizations: list = []
-    Providers: list = []
+    ProviderOrganizations: list
+    Providers: list
     SecurityStamp: str
     TwoFactorEnabled: bool
     status: VaultwardenUserStatus = Field(
@@ -99,10 +99,10 @@ class VaultwardenUser(UserProfile):
 
 # TODO: add definition of attribute's types
 class SyncData(PermissiveBaseModel):
-    Ciphers: list[dict] = []
-    Collections: list[dict] = []
-    Domains: dict | None = {}
-    Folders: list[dict] = []
-    Policies: list[dict] = []
+    Ciphers: list[dict]
+    Collections: list[dict]
+    Domains: dict | None
+    Folders: list[dict]
+    Policies: list[dict]
     Profile: UserProfile
-    Sends: list[dict] = []
+    Sends: list[dict]

--- a/src/vaultwarden/utils/string_cases.py
+++ b/src/vaultwarden/utils/string_cases.py
@@ -1,0 +1,10 @@
+def pascal_case_to_camel_case(pascal: str) -> str:
+    """Convert a PascalCase string to camelCase.
+
+    Args:
+        pascal: The string to convert.
+
+    Returns:
+        The converted camelCase string.
+    """
+    return pascal[0].lower() + pascal[1:]


### PR DESCRIPTION
Fixes #9 

Following v1.31.0 of https://github.com/dani-garcia/vaultwarden, all API fields were changed from Pascal Case to Camel case.

In order to be compatible with previous versions and this new one, I added an alias generator and a customized base model.