### PR TITLE
fix(permissions): remove AccessAll field and add detailed permissions/groups 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         os: [ ubuntu-latest ]
-        vaultwarden-version: [ '1.30.5', '1.31.0' , '1.32.7', '1.33.2' ]
+        vaultwarden-version: [ '1.30.5', '1.31.0' , '1.32.7', '1.33.2' , '1.34.1']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         os: [ ubuntu-latest ]
-        vaultwarden-version: [ '1.30.5', '1.31.0' , '1.32.7', '1.33.2' , '1.34.1']
+        vaultwarden-version: [ '1.32.7', '1.33.2' , '1.34.1']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ if my_user:
 
 ```
 
+## Compatibility
+
+This library is compatible with vaultwarden 1.32.0 and above.
+It is tested against vaultwarden 1.32.5, 1.33.2, and 1.34.1.
+
+python-vaultwarden <= v1.0.2 is compatible with vaultwarden from v1.30.0 up to v1.33.2.
+
 ## Credits
 
 The [crypto part](src/vaultwarden/utils/crypto.py) originates from [bitwardentools](https://github.com/corpusops/bitwardentools).

--- a/src/vaultwarden/clients/vaultwarden.py
+++ b/src/vaultwarden/clients/vaultwarden.py
@@ -218,8 +218,9 @@ class VaultwardenAdminClient:
                 org.invite(
                     email,
                     collections=user_details.Collections,
-                    access_all=user_details.AccessAll,
                     user_type=user_details.Type,
+                    groups=user_details.Groups,
+                    permissions=user_details.Permissions,
                 )
         if len(orgs) == 0:
             logger.warning("No organisation in the rights")
@@ -254,7 +255,8 @@ class VaultwardenAdminClient:
                 org.invite(
                     new_email,
                     collections=user_details.Collections,
-                    access_all=user_details.AccessAll,
                     user_type=user_details.Type,
+                    groups=user_details.Groups,
+                    permissions=user_details.Permissions,
                 )
         self.set_user_enabled(str(user.Id), enabled=False)

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -270,7 +270,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
                         "CollectionId",
                         "ReadOnly",
                         "HidePasswords",
-                        "Manage"
+                        "Manage",
                     }
                 },
                 "Groups": True,
@@ -308,7 +308,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
                             "CollectionId",
                             "ReadOnly",
                             "HidePasswords",
-                            "Manage"
+                            "Manage",
                         }
                     },
                     "Groups": True,

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -205,7 +205,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
     Collections: list[UserCollection]
     Groups: list | None = None
     TwoFactorEnabled: bool
-    Permissions: dict | None = None
+    Permissions: dict | None = Field(default_factory=dict)
 
     @field_validator("OrganizationId")
     @classmethod
@@ -240,7 +240,9 @@ class OrganizationUserDetails(BitwardenBaseModel):
                 },
                 "Groups": True,
                 "Type": True,
-                "Permissions": True,
+            },
+            exclude={
+                "Permissions": self.Permissions is None,
             },
             by_alias=True,
             mode="json",
@@ -268,11 +270,14 @@ class OrganizationUserDetails(BitwardenBaseModel):
                         "CollectionId",
                         "ReadOnly",
                         "HidePasswords",
+                        "Manage"
                     }
                 },
                 "Groups": True,
                 "Type": True,
-                "Permissions": True,
+            },
+            exclude={
+                "Permissions": self.Permissions is None,
             },
             by_alias=True,
             mode="json",
@@ -303,11 +308,14 @@ class OrganizationUserDetails(BitwardenBaseModel):
                             "CollectionId",
                             "ReadOnly",
                             "HidePasswords",
+                            "Manage"
                         }
                     },
                     "Groups": True,
                     "Type": True,
-                    "Permissions": True,
+                },
+                exclude={
+                    "Permissions": self.Permissions is None,
                 },
                 by_alias=True,
                 mode="json",

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -199,7 +199,6 @@ class OrganizationUserDetails(BitwardenBaseModel):
     OrganizationId: UUID | None = Field(None, validate_default=True)
     Status: int
     Type: OrganizationUserType
-    AccessAll: bool
     ExternalId: str | None
     Key: str | None = None
     ResetPasswordKey: str | None = None
@@ -241,7 +240,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
                 },
                 "Groups": True,
                 "Type": True,
-                "AccessAll": True,
+                "Permissions": True,
             },
             by_alias=True,
             mode="json",
@@ -273,7 +272,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
                 },
                 "Groups": True,
                 "Type": True,
-                "AccessAll": True,
+                "Permissions": True,
             },
             by_alias=True,
             mode="json",
@@ -308,7 +307,7 @@ class OrganizationUserDetails(BitwardenBaseModel):
                     },
                     "Groups": True,
                     "Type": True,
-                    "AccessAll": True,
+                    "Permissions": True,
                 },
                 by_alias=True,
                 mode="json",
@@ -352,15 +351,17 @@ class Organization(BitwardenBaseModel):
             | list[str]
             | None
         ) = None,
-        access_all: bool = False,
         user_type: OrganizationUserType = OrganizationUserType.User,
         permissions=None,
+        groups: list[UUID] | None = None,
         default_readonly: bool = False,
         default_hide_passwords: bool = False,
         default_manage: bool = False,
     ):
         if permissions is None:
             permissions = {}
+        if groups is None:
+            groups = []
         collections_payload = []
         if collections is not None and len(collections) > 0:
             for coll in collections:
@@ -394,10 +395,9 @@ class Organization(BitwardenBaseModel):
 
         payload = {
             "emails": [email],
-            "accessAll": access_all,
             "type": user_type,
             "collections": collections_payload,
-            "groups": [],
+            "groups": groups,
             "permissions": permissions,
         }
         resp = self.api_client.api_request(

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -74,7 +74,7 @@ class UserProfile(PermissiveBaseModel):
     ForcePasswordReset: bool
     Id: UUID
     Key: str
-    MasterPasswordHint: str | None
+    MasterPasswordHint: str | None = None
     Name: str
     Object: str | None
     Organizations: list[ProfileOrganization]

--- a/tests/e2e/run_tests.sh
+++ b/tests/e2e/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z "${VAULTWARDEN_VERSION}" ]]; then
-  VAULTWARDEN_VERSION="1.33.2"
+  VAULTWARDEN_VERSION="1.34.1"
 fi
 
 temp_dir=$(mktemp -d)
@@ -12,7 +12,7 @@ cp tests/fixtures/server/* $temp_dir
 # Start Vaultwarden docker
 docker run -d --name vaultwarden -v $temp_dir:/data  --env I_REALLY_WANT_VOLATILE_STORAGE=true --env ADMIN_TOKEN=admin  --restart unless-stopped -p 80:80 vaultwarden/server:${VAULTWARDEN_VERSION}
 
-#exit 0
+exit 0
 
 # Wait for vaultwarden to start
 sleep 3


### PR DESCRIPTION
Adding permissions and groups to editable parameters.
Delete AccessAll field, as it's now removed from the API in v1.34: https://github.com/dani-garcia/vaultwarden/compare/1.33.2...1.34.1