### PR TITLE
support argon2id & nested decryption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "hkdf >=0.0.3",
+    "argon2-cffi >= 25.1.0",
     "pycryptodome >=3.17.0",
     "pydantic >=2.5.0",
     "httpx >=0.24.1",

--- a/src/vaultwarden/clients/bitwarden.py
+++ b/src/vaultwarden/clients/bitwarden.py
@@ -68,10 +68,14 @@ class BitwardenAPIClient:
         )
         self._connect_token = ConnectToken.model_validate_json(resp.text)
 
+        import vaultwarden.models.bitwarden
+
         self._connect_token.master_key = make_master_key(
             password=self.password,
             salt=self.email,
-            iterations=self._connect_token.KdfIterations,
+            kdf=vaultwarden.models.bitwarden.Kdf.from_ConnectToken(
+                self._connect_token
+            ),
         )
 
     def _set_connect_token(self):
@@ -92,11 +96,16 @@ class BitwardenAPIClient:
             "identity/connect/token", headers=headers, data=payload
         )
         self._connect_token = ConnectToken.model_validate_json(resp.text)
+        import vaultwarden.models.bitwarden
+
         self._connect_token.master_key = make_master_key(
             password=self.password,
             salt=self.email,
-            iterations=self._connect_token.KdfIterations,
+            kdf=vaultwarden.models.bitwarden.Kdf.from_ConnectToken(
+                self._connect_token
+            ),
         )
+        return
 
     # login to api
     def _api_login(self) -> None:

--- a/src/vaultwarden/clients/bitwarden.py
+++ b/src/vaultwarden/clients/bitwarden.py
@@ -73,7 +73,7 @@ class BitwardenAPIClient:
         self._connect_token.master_key = make_master_key(
             password=self.password,
             salt=self.email,
-            kdf=vaultwarden.models.bitwarden.Kdf.from_ConnectToken(
+            kdf=vaultwarden.models.bitwarden.Kdf.from_connect_token(
                 self._connect_token
             ),
         )
@@ -101,7 +101,7 @@ class BitwardenAPIClient:
         self._connect_token.master_key = make_master_key(
             password=self.password,
             salt=self.email,
-            kdf=vaultwarden.models.bitwarden.Kdf.from_ConnectToken(
+            kdf=vaultwarden.models.bitwarden.Kdf.from_connect_token(
                 self._connect_token
             ),
         )

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -29,7 +29,7 @@ from pydantic_core.core_schema import (
 )
 
 from vaultwarden.clients.bitwarden import BitwardenAPIClient
-from vaultwarden.models.enum import CipherType, OrganizationUserType, KdfType
+from vaultwarden.models.enum import CipherType, KdfType, OrganizationUserType
 from vaultwarden.models.exception_models import BitwardenError
 from vaultwarden.models.permissive_model import PermissiveBaseModel
 from vaultwarden.utils.crypto import decrypt, encrypt
@@ -74,7 +74,8 @@ def decode_bytes(
             return decrypt(handler(value), key)
         except Exception:
             continue
-    raise ValueError(f"No key found")
+    raise ValueError("No key found")
+
 
 def decode_string(
     value: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
@@ -229,9 +230,7 @@ class _CipherBase(BitwardenBaseModel):
             context = cast(dict, info.context)
             cctx = cast(list[bytes], context.get("cctx"))
 
-            cctx.append(
-                decrypt(key, cctx[0])
-            )
+            cctx.append(decrypt(key, cctx[0]))
 
         v = handler(data)
 
@@ -801,7 +800,7 @@ class Organization(BitwardenBaseModel):
             context={
                 "parent_id": self.Id,
                 "client": self.api_client,
-                "cctx": [org_key], # crypto context
+                "cctx": [org_key],  # crypto context
             },
         )
         return res.Data

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -223,14 +223,14 @@ class _CipherBase(BitwardenBaseModel):
         handler: ModelWrapValidatorHandler[Self],
         info: ValidationInfo,
     ) -> Self:
-        if data.get("key") is not None:
+        if (key := data.get("key")) is not None:
             info.context["cctx"].append(
-                decrypt(data["key"], info.context["cctx"][0])
+                decrypt(key, info.context["cctx"][0])
             )
 
         v = handler(data)
 
-        if data.get("key") is not None:
+        if key is not None:
             info.context["cctx"].pop()
 
         return v
@@ -796,7 +796,7 @@ class Organization(BitwardenBaseModel):
             context={
                 "parent_id": self.Id,
                 "client": self.api_client,
-                "cctx": [org_key],
+                "cctx": [org_key], # crypto context
             },
         )
         return res.Data

--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -27,10 +27,9 @@ from pydantic_core.core_schema import (
     ValidationInfo,
     ValidatorFunctionWrapHandler,
 )
-from src.vaultwarden.models.enum import KdfType
 
 from vaultwarden.clients.bitwarden import BitwardenAPIClient
-from vaultwarden.models.enum import CipherType, OrganizationUserType
+from vaultwarden.models.enum import CipherType, OrganizationUserType, KdfType
 from vaultwarden.models.exception_models import BitwardenError
 from vaultwarden.models.permissive_model import PermissiveBaseModel
 from vaultwarden.utils.crypto import decrypt, encrypt

--- a/src/vaultwarden/models/enum.py
+++ b/src/vaultwarden/models/enum.py
@@ -27,3 +27,8 @@ class VaultwardenUserStatus(IntEnum):
     Enabled = 0
     Invited = 1
     Disabled = 2
+
+
+class KdfType(IntEnum):
+    Pbkdf2 = 0
+    Argon2id = 1

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -2,9 +2,8 @@ import time
 from uuid import UUID
 
 from pydantic import AliasChoices, Field, field_validator
-from src.vaultwarden.models.enum import KdfType
 
-from vaultwarden.models.enum import VaultwardenUserStatus
+from vaultwarden.models.enum import KdfType, VaultwardenUserStatus
 from vaultwarden.models.permissive_model import PermissiveBaseModel
 from vaultwarden.utils.crypto import decrypt
 

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -1,14 +1,12 @@
 import time
 from uuid import UUID
 
-import pydantic
 from pydantic import AliasChoices, Field, field_validator
+from src.vaultwarden.models.enum import KdfType
 
 from vaultwarden.models.enum import VaultwardenUserStatus
 from vaultwarden.models.permissive_model import PermissiveBaseModel
 from vaultwarden.utils.crypto import decrypt
-
-from src.vaultwarden.models.enum import KdfType
 
 
 class ConnectToken(PermissiveBaseModel):

--- a/src/vaultwarden/models/sync.py
+++ b/src/vaultwarden/models/sync.py
@@ -1,15 +1,18 @@
 import time
 from uuid import UUID
 
+import pydantic
 from pydantic import AliasChoices, Field, field_validator
 
 from vaultwarden.models.enum import VaultwardenUserStatus
 from vaultwarden.models.permissive_model import PermissiveBaseModel
 from vaultwarden.utils.crypto import decrypt
 
+from src.vaultwarden.models.enum import KdfType
+
 
 class ConnectToken(PermissiveBaseModel):
-    Kdf: int = 0
+    Kdf: KdfType = KdfType.Pbkdf2
     KdfIterations: int = 0
     KdfMemory: int | None = None
     KdfParallelism: int | None = None
@@ -22,7 +25,8 @@ class ConnectToken(PermissiveBaseModel):
     scope: str
     unofficialServer: bool = False
     ResetMasterPassword: bool | None = None
-    master_key: bytes | None = None
+
+    master_key: bytes | None = None  # pydantic.PrivateAttr(default=None)
 
     @field_validator("expires_in")
     @classmethod

--- a/src/vaultwarden/utils/crypto.py
+++ b/src/vaultwarden/utils/crypto.py
@@ -115,9 +115,7 @@ def is_encrypted(cipher_string):
         return True
 
 
-def make_master_key(
-    password: str, salt: str, kdf: "vaultwarden.models.bitwarden.Kdf"
-):
+def make_master_key(password: str, salt: str, kdf: "vaultwarden.models.bitwarden.Kdf"):
     import vaultwarden.models.bitwarden
 
     assert isinstance(salt, str)
@@ -186,9 +184,7 @@ def aes_encrypt(plaintext, key, charset="utf-8"):
 
 def encrypt_sym(plaintext, key, to_bytes=False, *a, **kw):
     # inspired from bitwarden/jslib:src/services/crypto.service.ts
-    typ, (iv, ct, mac) = int(CIPHERS.sym), aes_encrypt(
-        plaintext, key, *a, **kw
-    )
+    typ, (iv, ct, mac) = int(CIPHERS.sym), aes_encrypt(plaintext, key, *a, **kw)
     if mac:
         mac = mac.digest()
     if to_bytes:
@@ -269,9 +265,7 @@ def decrypt_bytes(cipher_bytes, key, *a, **kw):
         ct = cipher_bytes[49:]
         ret = decrypt_sym(ct, key, iv, mac)
     else:
-        raise UnimplementedError(
-            f"{typ} encType decryption is not implemented"
-        )
+        raise UnimplementedError(f"{typ} encType decryption is not implemented")
     return ret
 
 

--- a/tests/fixtures/server/db.sqlite3
+++ b/tests/fixtures/server/db.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8c11a331ba097f1644b297885cd09b4ac5fc975ed5605176c880bc5cf08a813
-size 245760
+oid sha256:45f2e69202615d295d7687fa4752e189ad29cae7de8852101f93f0b679cbcab6
+size 262144


### PR DESCRIPTION
Hi,

I've looked into this library as a replacement.
This PR is meant to allow discussing some design aspects of the library.

In the first place I need to be able to lookup credentials, therefore I worked on decryption.

Decryption is dealt with during validation, using a pydantic WrapValidator.
Item specific keys, as with CipherDetails or Attachments, can be pushed to the stack when working the item, popped afterwards to continue with the org key. Attachment misses this glue atm.

Encryption would be a WrapSerializer.

Argon2id got some initial thoughts already as well.

I've used allow=forbid for development purposes.

I'd be glad if you could look into this and let me know what think about it.
I could even split this into different PRs (crypto-serdes, argon2id) if required.
