### PR TITLE
Create Organisations

### DIFF
--- a/src/vaultwarden/clients/bitwarden.py
+++ b/src/vaultwarden/clients/bitwarden.py
@@ -143,8 +143,7 @@ class BitwardenAPIClient:
         used_id = user_id if user_id else self.sync().Profile.Id
         resp = self.api_request("GET", f"api/users/{used_id}/public-key")
         return resp.json().get("publicKey")
-    
-    
+
     def create_organisation(
         self,
         name: str,

--- a/src/vaultwarden/clients/bitwarden.py
+++ b/src/vaultwarden/clients/bitwarden.py
@@ -1,12 +1,18 @@
+from base64 import b64decode, b64encode
 from typing import Literal
 from uuid import UUID
 
 from httpx import Client, Response
-from base64 import b64decode, b64encode
 
 from vaultwarden.models.exception_models import BitwardenError
 from vaultwarden.models.sync import ConnectToken, SyncData
-from vaultwarden.utils.crypto import make_master_key, encrypt_asym, encrypt_sym, make_asym_key, make_org_key
+from vaultwarden.utils.crypto import (
+    encrypt_asym,
+    encrypt_sym,
+    make_asym_key,
+    make_master_key,
+    make_org_key,
+)
 from vaultwarden.utils.logger import log_raise_for_status
 
 
@@ -134,20 +140,30 @@ class BitwardenAPIClient:
         )
 
     def get_public_key_for_user(self, user_id: UUID | None = None) -> str:
-        resp = self.api_request(
-            "GET", f"api/users/{self._sync.Profile.Id if not user_id else user_id}/public-key"
-        )
+        used_id = user_id if user_id else self.sync().Profile.Id
+        resp = self.api_request("GET", f"api/users/{used_id}/public-key")
         return resp.json().get("publicKey")
-
-
-    def create_organisation(self, name: str, email: str, default_collection_name: str = "DefaultCollection") -> Response:        
-        encrypted_priv, pub, _ = make_asym_key(self._connect_token.user_key)
+    
+    
+    def create_organisation(
+        self,
+        name: str,
+        email: str,
+        default_collection_name: str = "DefaultCollection",
+    ) -> Response:
+        if not self.connect_token:
+            raise BitwardenError("Not connected")
 
         public_key_user = b64decode(self.get_public_key_for_user())
         org_key = make_org_key()
-        protected_organisation_symetric_key = encrypt_asym(org_key, public_key_user)
+        protected_organisation_symetric_key = encrypt_asym(
+            org_key, public_key_user
+        )
 
-        collection = encrypt_sym(bytes(default_collection_name, "utf-8"), org_key)
+        collection = encrypt_sym(
+            bytes(default_collection_name, "utf-8"), org_key
+        )
+        encrypted_priv, pub, _ = make_asym_key(self.connect_token.user_key)
 
         payload = {
             "key": protected_organisation_symetric_key,
@@ -155,11 +171,11 @@ class BitwardenAPIClient:
             "name": name,
             "billingEmail": email,
             "initiationPath": "New organization creation in-product",
-             "keys": {
+            "keys": {
                 "publicKey": b64encode(pub).decode("utf-8"),
-                "encryptedPrivateKey": encrypted_priv
+                "encryptedPrivateKey": encrypted_priv,
             },
-            "planType": 0
+            "planType": 0,
         }
         resp = self._api_request("POST", "api/organizations", json=payload)
         return resp

--- a/src/vaultwarden/utils/crypto.py
+++ b/src/vaultwarden/utils/crypto.py
@@ -280,6 +280,9 @@ def make_asym_key(key, stretch=True):
     private_key = asym_key.exportKey("DER", pkcs=8)
     return encrypt_sym(private_key, key), public_key, private_key
 
+def make_org_key():
+    return token_bytes(64)
+
 
 def gen_password(length=32, alphabet=None):
     alphabet = string.ascii_letters + string.digits

--- a/src/vaultwarden/utils/crypto.py
+++ b/src/vaultwarden/utils/crypto.py
@@ -280,6 +280,7 @@ def make_asym_key(key, stretch=True):
     private_key = asym_key.exportKey("DER", pkcs=8)
     return encrypt_sym(private_key, key), public_key, private_key
 
+
 def make_org_key():
     return token_bytes(64)
 

--- a/tests/e2e/test_bitwarden.py
+++ b/tests/e2e/test_bitwarden.py
@@ -123,6 +123,11 @@ class BitwardenBasic(unittest.TestCase):
         self.assertEqual(len(res[0].CollectionIds), 2)
         cipher.update_collection(old_colls)
 
+    def test_add_organsiation(self):
+        res = self.bitwarden.create_organisation("test_me", "me@example.com")
+        self.assertTrue(res.is_success)
+
+
     def test_deduplicate(self):
         # Todo build test fixtures and delete them at the end of the test
         return

--- a/tests/e2e/test_bitwarden.py
+++ b/tests/e2e/test_bitwarden.py
@@ -124,7 +124,7 @@ class BitwardenBasic(unittest.TestCase):
         cipher.update_collection(old_colls)
 
     def test_add_organsiation(self):
-        res = self.bitwarden.create_organisation("test_me", "me@example.com")
+        res = bitwarden.create_organisation("test_me", "me@example.com")
         self.assertTrue(res.is_success)
 
 


### PR DESCRIPTION
Hello,
This adds the ability to create new organisations by providing the name, billing email, and optionally a name for the default collection to the `create_organisation` method of the `BitwardenAPIClient`.
It also adds tests for the method.