### PR TITLE
fix: issue with delete user

### DIFF
--- a/src/vaultwarden/clients/vaultwarden.py
+++ b/src/vaultwarden/clients/vaultwarden.py
@@ -145,7 +145,11 @@ class VaultwardenAdminClient:
     def delete(self, identifier: str | UUID) -> bool:
         logger.info(f"Deleting {identifier} account")
         try:
-            self._admin_request("POST", f"users/{identifier}/delete")
+            self._admin_request(
+                "POST",
+                f"users/{identifier}/delete",
+                headers={"Content-Type": "application/json"},
+            )
         except HTTPStatusError as e:
             logger.warning(f"Failed to delete {identifier} {e}")
             return False


### PR DESCRIPTION
the user delete api call fails on vaultwarden when "content-type: app/json" is not provided in http headers:

```
>>> client.delete(u.Id)
ERROR:vaultwarden.utils.logger:Error: 404
WARNING:vaultwarden.utils.logger:Failed to <redacted user.id> Client error '404 Not Found' for url 'https://<redacted>/admin/users/<redacted user.id>/delete'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
False
```

This PR fixes that issue. It is an easy fix. You can also change it yourself on the next release and discard this PR.