### PR TITLE
Fix 404 for set_users method

### DIFF
--- a/src/vaultwarden/models/bitwarden.py
+++ b/src/vaultwarden/models/bitwarden.py
@@ -429,10 +429,19 @@ class OrganizationCollection(BitwardenBaseModel):
                     }
                     for user_id in users
                 ]
+
+        org_object = get_organization(self.bitwarden_client, self.OrganizationId)
+        data_payload = {
+            "name": encrypt(2, self.Name, org_object.key()),
+            "users": users_payload,
+            "groups": [],
+            "id": str(self.Id)
+        }
+
         return self.api_client.api_request(
             "PUT",
-            f"api/organizations/{self.OrganizationId}/collections/{self.Id}/users",
-            json=users_payload,
+            f"api/organizations/{self.OrganizationId}/collections/{self.Id}",
+            json=data_payload,
         )
 
     # Delete collection


### PR DESCRIPTION
Since vaultwarden 1.35.4 version there are a lot of deleted endpoints (https://github.com/dani-garcia/vaultwarden/pull/6867/changes#diff-4a9695da74664125793a066394e03e68892b306081e00dc7861f2da1145b0c48L39) including `api/organizations/<org_id>/collections/<col_id>/users`.
This PR is fix updating collection users in method set_users for class OrganizationCollection